### PR TITLE
Proposed work-around for timing issue in t/90_csv.t

### DIFF
--- a/t/90_csv.t
+++ b/t/90_csv.t
@@ -64,8 +64,14 @@ my @in =
 
 sub in {
     my @i = @in;
+    my $sleep = do {
+        my $start = now;
+        for 1 .. 10000 -> $n { my $y = $n * ($n - 1) + ($n - 1) / $n; }
+        (max 0.7, now - $start).round (0.01);
+        };
+    #say "Zzz... = $sleep";
     my $sup = Supply.new;
-    start { sleep (0.7); $sup.emit ($_) for @data; $sup.done; };
+    start { sleep ($sleep); $sup.emit ($_) for @data; $sup.done; };
     @i.push: $sup;
     @i;
     }


### PR DESCRIPTION
In this proposed work-around, the code times how long a loop which does simple math takes to complete; then uses said completion time as the value to sleep for before emitting from the Supply.

This should scale the time-to-sleep with the capabilities and current load of the machine on which the tests run.

As for where the actual bug is, my guess is somewhere inside the guts of Supply.