### PR TITLE
Fix license field in META6.json

### DIFF
--- a/META6.json
+++ b/META6.json
@@ -12,7 +12,7 @@
     },
   "repo-type"    : "git",
   "source-url"   : "git://github.com/Tux/CSV.git",
-  "license"      : "http://www.perlfoundation.org/artistic_license_2_0",
+  "license"      : "Artistic-2.0",
   "support"      : {
     "irc"        : "irc://irc.perl.org/#csv"
     }


### PR DESCRIPTION
See https://design.perl6.org/S22.html#license spec is now to use
standardized name fields and not URL's for the license field.