### PR TITLE
Takes IO::String out of the big file refs #24

### DIFF
--- a/META6.json
+++ b/META6.json
@@ -8,7 +8,8 @@
   "depends"       : [ "Slang::Tuxic", "File::Temp" ],
   "test-depends"  : [ "Test", "Test::META"         ],
   "provides"      : {
-    "Text::CSV"   : "lib/Text/CSV.pm"
+      "Text::CSV"   : "lib/Text/CSV.pm",
+      "IO::String"  : "lib/IO/String.pm6"
     },
   "repo-type"     : "git",
   "source-url"    : "git://github.com/Tux/CSV.git",

--- a/lib/IO/String.pm6
+++ b/lib/IO/String.pm6
@@ -1,0 +1,60 @@
+use Slang::Tuxic; # Need it for space before parenthesis
+
+unit class IO::String is IO::Handle;
+
+has      $.nl-in   is rw;
+has      $.nl-out  is rw;
+has Bool $.ro      is rw is default(False);
+has Str  $!str;
+has Str  @!content;
+
+# my $fh = IO::String.new ($foo);
+multi method new (Str $str! is rw, *%init) {
+    my \obj = self.new ($str.Str, |%init);
+    obj.bind-str ($str);
+    obj;
+}
+
+    # my $fh = IO::String.new ("foo");
+    multi method new (Str $str!, *%init) {
+        my \obj = self.bless;
+        obj.nl-in  = $*IN.nl-in;
+        obj.nl-out = $*OUT.nl-out;
+        obj.ro     = %init<ro>     if %init<ro>:exists;
+        obj.nl-in  = %init<nl-in>  if %init<nl-in>:exists;
+        obj.nl-out = %init<nl-out> if %init<nl-out>:exists;
+        obj.print ($str);
+        obj;
+        }
+
+    method bind-str (Str $s is rw) {
+        $!str := $s;
+        }
+
+    method print (*@what) {
+        if (my Str $str = @what.join ("")) {
+            my Str @x = $str eq "" || !$.nl-in.defined
+                ??  $str
+                !! |$str.split ($.nl-in, :v).map (-> $a, $b? --> Str { $a ~ ($b // "") });
+            @x.elems > 1 && @x.tail eq "" and @x.pop;
+            @!content.push: |@x;
+            }
+        self;
+        }
+
+    method print-nl {
+        self.print ($.nl-out);
+        }
+
+    method get {
+        @!content ?? @!content.shift !! Str;
+        }
+
+    method close {
+        $!str.defined && !$.ro and $!str = ~ self;
+        }
+
+    method Str {
+        @!content.join ("");
+        }
+

--- a/lib/Text/CSV.pm
+++ b/lib/Text/CSV.pm
@@ -3,6 +3,7 @@
 use v6.c;
 use Slang::Tuxic;
 use File::Temp;
+use IO::String;
 
 my $VERSION = "0.009";
 
@@ -99,65 +100,7 @@ sub progress (*@y) {
     $x.say;
     } # progress
 
-# I don't want this inside Text::CSV
-class IO::String is IO::Handle {
 
-    has      $.nl-in   is rw;
-    has      $.nl-out  is rw;
-    has Bool $.ro      is rw is default(False);
-    has Str  $!str;
-    has Str  @!content;
-
-    # my $fh = IO::String.new ($foo);
-    multi method new (Str $str! is rw, *%init) {
-        my \obj = self.new ($str.Str, |%init);
-        obj.bind-str ($str);
-        obj;
-        }
-
-    # my $fh = IO::String.new ("foo");
-    multi method new (Str $str!, *%init) {
-        my \obj = self.bless;
-        obj.nl-in  = $*IN.nl-in;
-        obj.nl-out = $*OUT.nl-out;
-        obj.ro     = %init<ro>     if %init<ro>:exists;
-        obj.nl-in  = %init<nl-in>  if %init<nl-in>:exists;
-        obj.nl-out = %init<nl-out> if %init<nl-out>:exists;
-        obj.print ($str);
-        obj;
-        }
-
-    method bind-str (Str $s is rw) {
-        $!str := $s;
-        }
-
-    method print (*@what) {
-        if (my Str $str = @what.join ("")) {
-            my Str @x = $str eq "" || !$.nl-in.defined
-                ??  $str
-                !! |$str.split ($.nl-in, :v).map (-> $a, $b? --> Str { $a ~ ($b // "") });
-            @x.elems > 1 && @x.tail eq "" and @x.pop;
-            @!content.push: |@x;
-            }
-        self;
-        }
-
-    method print-nl {
-        self.print ($.nl-out);
-        }
-
-    method get {
-        @!content ?? @!content.shift !! Str;
-        }
-
-    method close {
-        $!str.defined && !$.ro and $!str = ~ self;
-        }
-
-    method Str {
-        @!content.join ("");
-        }
-    }
 
 class RangeSet {
 

--- a/t/32_getline.t
+++ b/t/32_getline.t
@@ -4,6 +4,7 @@ use v6;
 use Slang::Tuxic;
 
 use Text::CSV;
+use IO::String;
 use Test;
 
 my $fh = IO::String.new (q:to/EOC/);

--- a/t/46_eol_si.t
+++ b/t/46_eol_si.t
@@ -5,6 +5,7 @@ use Slang::Tuxic;
 
 use Test;
 use Text::CSV;
+use IO::String;
 
 my Str $efn;
 my Str @rs  = "\n", "\r\n", "\r";

--- a/t/77_getall.t
+++ b/t/77_getall.t
@@ -5,6 +5,7 @@ use Slang::Tuxic;
 
 use Test;
 use Text::CSV;
+use IO::String;
 
 my $csv = Text::CSV.new;
 my $tfn = "_77test.csv";


### PR DESCRIPTION
Mainly to make the file lighter.