### PR TITLE
♻ IO::String

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,6 @@ rust*/target
 sandbox/
 files/
 *~
+
+# Comma stuff ignored
+.idea/

--- a/META6.json
+++ b/META6.json
@@ -9,7 +9,7 @@
   "test-depends"  : [ "Test", "Test::META"         ],
   "provides"      : {
     "Text::CSV"   : "lib/Text/CSV.rakumod",
-    "IO::String"  : "lib/IO/String.rakumod"
+    "Text::IO::String"  : "lib/Text/IO/String.rakumod"
     },
   "repo-type"     : "git",
   "source-url"    : "git://github.com/Tux/CSV.git",

--- a/lib/Text/CSV.rakumod
+++ b/lib/Text/CSV.rakumod
@@ -2,7 +2,7 @@
 
 use Slang::Tuxic;
 use File::Temp;
-use IO::String;
+use Text::IO::String;
 
 my $VERSION = "0.010";
 
@@ -1704,7 +1704,7 @@ class Text::CSV {
                 $in.list.elems or return;
                 given $in.list[0] {
                     when Str {  # AoS
-                        $io-in = IO::String.new ($in.list.join ($!eol // "\n"));
+                        $io-in = Text::IO::String.new ($in.list.join ($!eol // "\n"));
                         }
                     default {   # AoA, AoH
                         $fragment ~~ s:i{^ "row=" } = "" and
@@ -1722,7 +1722,7 @@ class Text::CSV {
                     }
                 }
             when Capture {
-                $io-in = IO::String.new ($in.list.map ( -> \x --> Str { x.Str }).join ($!eol // "\n"));
+                $io-in = Text::IO::String.new ($in.list.map ( -> \x --> Str { x.Str }).join ($!eol // "\n"));
                 }
             when Supply {
                 $fragment ~~ s:i{^ "row=" } = "" and self.rowrange ($fragment);

--- a/lib/Text/IO/String.rakumod
+++ b/lib/Text/IO/String.rakumod
@@ -1,6 +1,6 @@
 use Slang::Tuxic; # Need it for space before parenthesis
 
-unit class IO::String is IO::Handle;
+unit class Text::IO::String is IO::Handle;
 
 has      $.nl-in   is rw;
 has      $.nl-out  is rw;
@@ -8,14 +8,14 @@ has Bool $.ro      is rw is default(False);
 has Str  $!str;
 has Str  @!content;
 
-# my $fh = IO::String.new ($foo);
+# my $fh = Text::IO::String.new ($foo);
 multi method new (Str $str! is rw, *%init) {
     my \obj = self.new ($str.Str, |%init);
     obj.bind-str ($str);
     obj;
     }
 
-# my $fh = IO::String.new ("foo");
+# my $fh = Text::IO::String.new ("foo");
 multi method new (Str $str!, *%init) {
     my \obj = self.bless;
     obj.nl-in  = $*IN.nl-in;

--- a/t/32_getline.t
+++ b/t/32_getline.t
@@ -4,10 +4,10 @@ use v6;
 use Slang::Tuxic;
 
 use Text::CSV;
-use IO::String;
+use Text::IO::String;
 use Test;
 
-my $fh = IO::String.new (q:to/EOC/);
+my $fh = Text::IO::String.new (q:to/EOC/);
 a,b,c
 1,foo,bar
 EOC
@@ -22,7 +22,7 @@ is (+$csv.error-diag, 2012, "Parse should have stopped with EOF");
 $fh.close;
 
 # Check that while stops on error in getline
-$fh = IO::String.new (q:to/EOC/);
+$fh = Text::IO::String.new (q:to/EOC/);
 a,b,c
 1,foo,bar
 2,"d" fail,3

--- a/t/46_eol_si.t
+++ b/t/46_eol_si.t
@@ -5,7 +5,7 @@ use Slang::Tuxic;
 
 use Test;
 use Text::CSV;
-use IO::String;
+use Text::IO::String;
 
 my Str $efn;
 my Str @rs  = "\n", "\r\n", "\r";
@@ -22,7 +22,7 @@ for (|@rs) -> $rs {
             for (0, 1) -> $pass {
                 my IO::Handle $fh;
 
-                $fh = IO::String.new ($efn, nl-in => $rs);
+                $fh = Text::IO::String.new ($efn, nl-in => $rs);
                 $fh.nl-out = $ors.defined ?? $ors !! "";
 
                 my $s_eol = join " - ", $rs.perl, $ors.perl, $eol.perl;
@@ -67,7 +67,7 @@ ok (True, "Auto-detecting \\r");
     for ("\n", "\r\n", "\r") -> $eol {
         my $s_eol = $eol.perl;
         $efn = qq{$row$eol$row$eol$row$eol\x91};
-        my $fh = IO::String.new ($efn, nl-in => Str, nl-out => Str);
+        my $fh = Text::IO::String.new ($efn, nl-in => Str, nl-out => Str);
         my $c = Text::CSV.new (:auto_diag);
         is ( $c.eol (),                  Str,       "default EOL");
         is ([$c.getline ($fh, :!meta)],  [ @row, ], "EOL 1 $s_eol");
@@ -80,12 +80,12 @@ ok (True, "Auto-detecting \\r");
 
 ok (True, "EOL undefined");
 {   ok (my $csv = Text::CSV.new (eol => Str), "new csv with eol => Str");
-    my $fh = IO::String.new ($efn);
+    my $fh = Text::IO::String.new ($efn);
     ok ($csv.print ($fh, [1, 2, 3]), "print 1");
     ok ($csv.print ($fh, [4, 5, 6]), "print 2");
     $fh.close;
 
-    $fh = IO::String.new ($efn);
+    $fh = Text::IO::String.new ($efn);
     ok ((my @row = $csv.getline ($fh, :!meta)), "getline");
     is (@row.elems, 5,                          "# fields");
     is ([|@row], [ 1, 2, 34, 5, 6 ],            "fields 1+2");
@@ -100,7 +100,7 @@ for ("!", "!!", "!\n", "!\n!", "!!!!!!!!", "!!!!!!!!!!",
     ok (True, "EOL $s_eol");
     ok ((my $csv = Text::CSV.new (:$eol)), "new csv with eol => $s_eol");
     $efn = "";
-    my $fh = IO::String.new ($efn, nl-out => Str);
+    my $fh = Text::IO::String.new ($efn, nl-out => Str);
     ok ($csv.print ($fh, [1, 2, 3]), "print 1");
     ok ($csv.print ($fh, [4, 5, 6]), "print 2");
     $fh.close;
@@ -109,7 +109,7 @@ for ("!", "!!", "!\n", "!\n!", "!!!!!!!!", "!!!!!!!!!!",
     for (Str, "", "\n", $eol, "!", "!\n", "\n!", "!\n!", "\n!\n") -> $rs {
         my $s_rs = $rs.perl;
         ok (True, "with RS $s_rs / EOL $s_eol");
-        my $fh  = IO::String.new ($efn, :ro, nl-in => $rs);
+        my $fh  = Text::IO::String.new ($efn, :ro, nl-in => $rs);
         my @row = $csv.getline ($fh, :!meta);
         if (@row.elems == 3 && @row[2] eq "3") {
             is (@row.elems, 3,                          "field count");

--- a/t/77_getall.t
+++ b/t/77_getall.t
@@ -5,7 +5,7 @@ use Slang::Tuxic;
 
 use Test;
 use Text::CSV;
-use IO::String;
+use Text::IO::String;
 
 my $csv = Text::CSV.new;
 my $tfn = "_77test.csv";
@@ -120,26 +120,26 @@ for ("\n", "\r") -> $eol {
     }
 
 {   ok (my $csv = Text::CSV.new, "new for sep=");
-    my $fh = IO::String.new (qq{sep=;\n"a b";3\n});
+    my $fh = Text::IO::String.new (qq{sep=;\n"a b";3\n});
     is-deeply ($csv.getline_all ($fh), [["a b", "3"],], "valid sep=");
     is (+$csv.error_diag, 2012, "EOF");
     }
 
 {   ok (my $csv = Text::CSV.new, "new for sep=");
-    my $fh = IO::String.new (qq{sep=;\n"a b",3\n});
+    my $fh = Text::IO::String.new (qq{sep=;\n"a b",3\n});
     is-deeply ($csv.getline_all ($fh), [], "invalid sep=");
     is (+$csv.error_diag, 2023, "error");
     }
 
 {   ok (my $csv = Text::CSV.new, "new for sep=");
-    my $fh = IO::String.new (qq{sep=XX\n"a b"XX3\n});
+    my $fh = Text::IO::String.new (qq{sep=XX\n"a b"XX3\n});
     is-deeply ($csv.getline_all ($fh), [["a b", "3"],], "multibyte sep=");
     is (+$csv.error_diag, 2012, "EOF");
     }
 
 {   ok (my $csv = Text::CSV.new, "new for sep=");
     # To check that it is *only* supported on the first line
-    my $fh = IO::String.new (qq{sep=;\n"a b";3\nsep=,\n"a b",3\n});
+    my $fh = Text::IO::String.new (qq{sep=;\n"a b";3\nsep=,\n"a b",3\n});
     is-deeply ($csv.getline_all ($fh),
 	[["a b","3"],["sep=,"]], "sep= not on 1st line");
     is (+$csv.error_diag, 2023, "error");

--- a/t/80_diag.t
+++ b/t/80_diag.t
@@ -5,6 +5,7 @@ use Slang::Tuxic;
 
 use Test;
 use Text::CSV;
+use Text::IO::String;
 
 my %err;
 
@@ -126,7 +127,7 @@ for    (Str,            # No spec at all
     my $csv = Text::CSV.new;
     my $e;
     my @r;
-    {   @r = $csv.fragment (IO::String.new (""), $spec);
+    {   @r = $csv.fragment (Text::IO::String.new (""), $spec);
         CATCH { default { $e = $_; 1; }}
         }
     #$csv.error-diag;

--- a/t/85_util.t
+++ b/t/85_util.t
@@ -5,6 +5,7 @@ use Slang::Tuxic;
 
 use Test;
 use Text::CSV;
+use Text::IO::String;
 
 my $csv = Text::CSV.new;
 
@@ -15,7 +16,7 @@ for < , ; > -> $sep {
     $data ~~ s:g{ "," } = $sep;
 
     $csv.column-names (False);
-    {   my $fh = IO::String.new: $data;
+    {   my $fh = Text::IO::String.new: $data;
 	ok (my $slf = $csv.header ($fh), "header");
 	is ($slf, $csv, "Return self");
 	is ($csv.sep, $sep, "Sep = $sep");
@@ -25,7 +26,7 @@ for < , ; > -> $sep {
 	}
 
     $csv.column-names (False);
-    {   my $fh = IO::String.new: $data;
+    {   my $fh = Text::IO::String.new: $data;
 	ok (my $slf = $csv.header ($fh), "header");
 	is ($slf, $csv, "Return self");
 	is ($csv.sep, $sep, "Sep = $sep");
@@ -41,7 +42,7 @@ for ",", ";", "|", "\t" -> $sep {
     $data ~~ s:g{ "," } = $sep;
 
     $csv.column-names (False);
-    {   my $fh = IO::String.new: $data;
+    {   my $fh = Text::IO::String.new: $data;
 	ok (my $slf = $csv.header ($fh, :$sep-set), "header with specific sep set");
 	is ($slf, $csv, "Return self");
 	is ($csv.sep, $sep, "Sep = $sep");
@@ -51,7 +52,7 @@ for ",", ";", "|", "\t" -> $sep {
 	}
 
     $csv.column-names (False);
-    {   my $fh = IO::String.new: $data;
+    {   my $fh = Text::IO::String.new: $data;
 	ok (my $slf = $csv.header ($fh, :$sep-set), "header with specific sep set");
 	is ($slf, $csv, "Return self");
 	is ($csv.sep, $sep, "Sep = $sep");
@@ -67,7 +68,7 @@ for   1010, "",
       1013, "a,a,b",
       2027, "a,\"b\nc\",d"
       -> $err, $data {
-    my $fh = IO::String.new: $data;
+    my $fh = Text::IO::String.new: $data;
     my $e;
     my $self;
     {   $self = $csv.header ($fh);
@@ -77,7 +78,7 @@ for   1010, "",
     is ($e.error, $err, "Error code $err");
     $err == 1013 and ok ($e.message.contains (< a(2)>), "Duplicate fields are reported");
     }
-{   my $fh = IO::String.new: "bar,bAr,bAR,BAR\n1,2,3,4";
+{   my $fh = Text::IO::String.new: "bar,bAr,bAR,BAR\n1,2,3,4";
     $csv.column-names (False);
     ok ($csv.header ($fh, munge-column-names => "none"), "non-unique unfolded headers");
     is-deeply ([ $csv.column-names ], [< bar bAr bAR BAR >], "Headers");
@@ -88,7 +89,7 @@ for < , ; > -> $sep {
     $data ~~ s:g{ "," } = $sep;
 
     $csv.column-names (False);
-    {   my $fh = IO::String.new: $data;
+    {   my $fh = Text::IO::String.new: $data;
 	ok (my $slf = $csv.header ($fh, :!set-column-names), "Header without column setting");
 	is ($slf, $csv, "Return self");
 	is ($csv.sep, $sep, "Sep = $sep");
@@ -104,7 +105,7 @@ for Str, "bar", "fc", "bar", "lc", "bar", "uc", "BAR", "none", "bAr",
     my Str $data = "bAr,foo\n1,2\n3,4,5\n";
 
     $csv.column-names (False);
-    my $fh = IO::String.new: $data;
+    my $fh = Text::IO::String.new: $data;
     ok (my $slf = $csv.header ($fh, :$munge-column-names), "header with fold {$munge-column-names.perl}");
     is ($csv.column-names[0], $hdr, "folded header to $hdr");
     }


### PR DESCRIPTION
This basically closes #26, renaming the included module. The other IO::String seems to be dormant (archived, in fact), and name clashes should be avoided, so made a judgment call to prepend the `Text` to make it a bit more part of the module (It might be a better idea, or an alternative, to spin it off and release it into the ecosystem...).
Anyway , naming issues have been resolved, and also for some reason it was used in some modules without explicitly "using" it; that's been fixed too.